### PR TITLE
Ensure sales deltas recorded for inventory adjustments

### DIFF
--- a/backend/reprocess-stocks.js
+++ b/backend/reprocess-stocks.js
@@ -113,7 +113,6 @@ function processEvent(eventId, payload) {
       }
       insertInventoryLevelStmt.run(item.variant.id, stockValue, reserveValue, timestamp);
       insertInventoryHistoryStmt.run(item.variant.id, stockValue, reserveValue, timestamp);
-      if (stockDelta > 0) {
       if (stockDelta !== 0) {
         recordSalesDelta(item.variant, stockDelta, timestamp);
       }

--- a/backend/server.js
+++ b/backend/server.js
@@ -780,7 +780,7 @@ function processStockWebhook(req, res, body) {
         }
         insertInventoryLevelStmt.run(item.variant.id, stockValue, reserveValue, timestamp);
         insertInventoryHistoryStmt.run(item.variant.id, stockValue, reserveValue, timestamp);
-        if (stockDelta > 0) {
+        if (stockDelta !== 0) {
           recordSalesDelta(item.variant, stockDelta, timestamp);
         }
       }

--- a/backend/worker.js
+++ b/backend/worker.js
@@ -675,7 +675,6 @@ async function processStockWebhook(env, request, body) {
         .bind(item.variant.id, stockValue, reserveValue, timestamp)
         .run();
 
-      if (stockDelta > 0) {
       if (stockDelta !== 0) {
         await recordSalesDelta(env, item.variant, stockDelta, timestamp);
       }


### PR DESCRIPTION
## Summary
- ensure the Cloudflare worker stock webhook records sales deltas for any non-zero inventory change
- align the local server and stock reprocessing script to persist sales deltas for both increases and decreases

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dcd20603a48333a7fceb905f76410c