### PR TITLE
Add dashboard refresh button and data reload path

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
         <select id="chartType">
             <option value="byColor">Продажі та попит за кольорами</option>
         </select>
+        <button type="button" id="refreshButton">Оновити дані</button>
     </div>
     <div class="chart-container">
         <div class="chart-section">


### PR DESCRIPTION
## Summary
- allow forcing the sales data request by extending `loadSalesData` to accept a `force` flag
- add a `refreshDashboard` workflow that reloads data, rebuilds selectors, and updates charts without duplicating listeners
- surface an "Оновити дані" button so operators can refresh the dashboard on demand

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcd20460108333941f8d0387d3de7d